### PR TITLE
Fix bandcamp metadata search

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "unidecode>=1.3.8",
     "setuptools>=68.0.0",
     "wheel>=0.45.1",
+    "httpx>=0.28.1",
 ]
 
 [project.license]

--- a/salmon/search/bandcamp.py
+++ b/salmon/search/bandcamp.py
@@ -10,7 +10,7 @@ class Searcher(BandcampBase, SearchMixin):
         releases = {}
         try:
             soup = await self.create_soup(
-                self.search_url, params={"q": searchstr}, allow_redirects=False
+                self.search_url, params={"q": searchstr}, follow_redirects=False
             )
             for meta in soup.select(".result-items .searchresult.data-search .result-info"):
                 try:

--- a/salmon/search/beatport.py
+++ b/salmon/search/beatport.py
@@ -9,7 +9,7 @@ from salmon.sources import BeatportBase
 class Searcher(BeatportBase, SearchMixin):
     async def search_releases(self, searchstr, limit):
         releases = {}
-        soup = await self.create_soup(self.search_url, params={"q": searchstr})
+        soup = await self.create_soup(self.search_url, params={"q": searchstr}, follow_redirects=True)
         for meta in soup.select(".bucket-items.ec-bucket li .release-meta"):
             try:
                 rls_id = int(

--- a/salmon/search/junodownload.py
+++ b/salmon/search/junodownload.py
@@ -16,7 +16,7 @@ class Searcher(JunodownloadBase, SearchMixin):
                 "solrorder": "relevancy",
                 "q[all][]": [searchstr],
             },
-            allow_redirects=False,
+            follow_redirects=False,
         )
         for meta in soup.find_all(
             'div',

--- a/salmon/sources/base.py
+++ b/salmon/sources/base.py
@@ -6,6 +6,7 @@ from collections import namedtuple
 from random import choice
 from string import Formatter
 
+import httpx
 import requests
 from bs4 import BeautifulSoup
 
@@ -80,8 +81,8 @@ class BaseScraper:
         params = params or {}
         r = await loop.run_in_executor(
             None,
-            lambda: requests.get(
-                url, params=params, headers=headers or HEADERS, timeout=7, **kwargs
+            lambda: httpx.get(
+                url, params=params, headers=headers or HEADERS, timeout=7, follow_redirects=kwargs.pop('follow_redirects', True), **kwargs
             ),
         )
         if r.status_code != 200:

--- a/salmon/tagger/sources/base.py
+++ b/salmon/tagger/sources/base.py
@@ -48,6 +48,7 @@ class MetadataMixin(ABC):
             "source": None,
             "url": url,
         }
+
         if rls_id:
             data["url"] = self.format_url(rls_id=rls_id, rls_name=data["title"])
         data["urls"] = [data["url"]]
@@ -110,11 +111,11 @@ class MetadataMixin(ABC):
             )
         elif re.search(r"original.*soundtrack", data["title"], flags=re.IGNORECASE):
             return data["title"], "Soundtrack"
-        elif len([a for a in data["artists"] if a[1] == "main"]) > 4:
+        elif len([a for a in data["artists"] if a[1] == "main"]) > 6:
             return data["title"], "Compilation"
-        #elif num_tracks < 3:
-        #    return data["title"], "Single"
-        elif num_tracks < 5:
+        elif num_tracks < 3:
+            return data["title"], "Single"
+        elif num_tracks < 6:
             return data["title"], "EP"
         return data["title"], data["rls_type"]
 

--- a/salmon/tagger/sources/deezer.py
+++ b/salmon/tagger/sources/deezer.py
@@ -89,11 +89,11 @@ class Scraper(DeezerBase, MetadataMixin):
                 result.append((unescape(artist), "guest"))
 
         if artists:
-            for a in artists.get("mainartist") or artists.get("main_artist", []):
+            for a in artists.get("mainartist", []) + artists.get("main_artist", []):
                 for b in re_split(a):
                     if (b, "main") not in result:
                         result.append((b, "main"))
-            for a in artists.get("featuredartist", []):
+            for a in artists.get("featuredartist", []) + artists.get("featuring", []):
                 for b in re_split(a):
                     if (b, "guest") not in result:
                         result.append((b, "guest"))

--- a/salmon/tagger/sources/tidal.py
+++ b/salmon/tagger/sources/tidal.py
@@ -12,6 +12,11 @@ ROLES = {
     "FEATURED": "guest",
 }
 
+RECORD_TYPES = {
+    "ALBUM": "Album",
+    "EP": "EP",
+    "SINGLE": "Single",
+}
 
 class Scraper(TidalBase, MetadataMixin):
 
@@ -36,6 +41,12 @@ class Scraper(TidalBase, MetadataMixin):
         if not date or date.endswith("01-01") and int(date[:4]) < 2013:
             return None
         return date
+
+    def parse_release_type(self, soup):
+        try:
+            return RECORD_TYPES[soup["type"]]
+        except KeyError:
+            return None
 
     def parse_release_label(self, soup):
         return parse_copyright(soup["copyright"])

--- a/uv.lock
+++ b/uv.lock
@@ -103,6 +103,21 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/ee/48ca1a7c89ffec8b6a0c5d02b89c305671d5ffd8d3c94acf8b8c408575bb/anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c", size = 100916 },
+]
+
+[[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -411,6 +426,15 @@ wheels = [
 ]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/35/2495c4ac46b980e4ca1f6ad6db102322ef3ad2410b79fdde159a4b0f3b92/exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc", size = 28883 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/cc/b7e31358aac6ed1ef2bb790a9746ac2c69bcb3c8588b41616914eb106eaf/exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b", size = 16453 },
+]
+
+[[package]]
 name = "flake8"
 version = "7.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -479,6 +503,15 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/38/3af3d3633a34a3316095b39c8e8fb4853a28a536e55d347bd8d8e9a14b03/h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d", size = 100418 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/04/ff642e65ad6b90db43e668d70ffb6736436c7ce41fcc549f4e9472234127/h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761", size = 58259 },
+]
+
+[[package]]
 name = "heybrochecklog"
 version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -488,6 +521,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/29/d2/b40e544fb0b535e4c25b82d9eb7cbceac4082219419b33195a85302bd9f8/heybrochecklog-1.3.2.tar.gz", hash = "sha256:559b1894db56105370c1666aa581fa036ce597c6405c343c581f1db9ed580e9b", size = 136792 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/49/e244ea073fd632e03a743e78a330bb5c0f98cd447c5df33025b51e7e8fe8/heybrochecklog-1.3.2-py3-none-any.whl", hash = "sha256:a5874e4f8a4f6484bbfed2dbc2ce8488985b540bd484427d996f9e9d04045728", size = 176052 },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/41/d7d0a89eb493922c37d343b607bc1b5da7f5be7e383740b4753ad8943e90/httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c", size = 85196 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/f5/72347bc88306acb359581ac4d52f23c0ef445b57157adedb9aee0cd689d2/httpcore-1.0.7-py3-none-any.whl", hash = "sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd", size = 78551 },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
 ]
 
 [[package]]
@@ -872,6 +933,7 @@ dependencies = [
     { name = "colorama" },
     { name = "dottorrent" },
     { name = "heybrochecklog" },
+    { name = "httpx" },
     { name = "jinja2" },
     { name = "musicbrainzngs" },
     { name = "mutagen" },
@@ -906,6 +968,7 @@ requires-dist = [
     { name = "dottorrent", specifier = ">=1.10.1" },
     { name = "flake8", marker = "extra == 'dev'", specifier = "==7.1.2" },
     { name = "heybrochecklog", specifier = ">=1.3.2" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "isort", marker = "extra == 'dev'", specifier = "==6.0.1" },
     { name = "jinja2", specifier = ">=3.1.2" },
     { name = "musicbrainzngs", specifier = ">=0.7.1" },
@@ -930,6 +993,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/32/d2/7b171caf085ba0d40d8391f54e1c75a1cda9255f542becf84575cfd8a732/setuptools-76.0.0.tar.gz", hash = "sha256:43b4ee60e10b0d0ee98ad11918e114c70701bc6051662a9a675a0496c1a158f4", size = 1349387 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/66/d2d7e6ad554f3a7c7297c3f8ef6e22643ad3d35ef5c63bf488bc89f32f31/setuptools-76.0.0-py3-none-any.whl", hash = "sha256:199466a166ff664970d0ee145839f5582cb9bca7a0a3a2e795b6a9cb2308e9c6", size = 1236106 },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
 ]
 
 [[package]]


### PR DESCRIPTION
Use httpx instead of requests (some bot protection is happening on bandcamp side, couldn't make it work with requests, even by setting a bunch of headers). TODO: migrate all requests to httpx ?

With httpx, follow_redirect is False by default (inverse from requests).