### PR TITLE
Fix/spectrals mixup

### DIFF
--- a/salmon/tagger/retagger.py
+++ b/salmon/tagger/retagger.py
@@ -227,7 +227,7 @@ def retag_files(path, album_changes, track_changes):
     click.secho("Retagged files.", fg="green")
 
 
-def rename_files(path, tags, metadata, auto_rename, source=None):
+def rename_files(path, tags, metadata, auto_rename, spectral_ids, source=None):
     """
     Call functions that generate the proposed changes, then print and prompt
     for confirmation. Apply the changes if user agrees.
@@ -285,9 +285,17 @@ def rename_files(path, tags, metadata, auto_rename, source=None):
                     )
                 )
                 new_path, new_path_ext = os.path.splitext(os.path.join(path, new_name))
-               # new_path = new_path[: 200 - len(new_path_ext) + len(os.path.dirname(path))] + new_path_ext
+                # new_path = new_path[: 200 - len(new_path_ext) + len(os.path.dirname(path))] + new_path_ext
                 new_path = new_path + new_path_ext
                 os.rename(os.path.join(path, filename), new_path)
+
+                # Update spectral_ids with new filenames, if spectrals were generated
+                if spectral_ids:
+                    for old_name, new_name in to_rename:
+                        for key, value in spectral_ids.items():
+                            if value == old_name:
+                                spectral_ids[key] = new_name
+
             move_non_audio_files(directory_move_pairs)
             delete_empty_folders(path)
     else:

--- a/salmon/uploader/__init__.py
+++ b/salmon/uploader/__init__.py
@@ -412,7 +412,7 @@ def edit_metadata(path, tags, metadata, source, rls_data, recompress, auto_renam
 
         if config.YES_ALL or click.confirm(
             click.style(
-                "Do you want to check for integrity of this upload?",
+                "\nDo you want to check for integrity of this upload?",
                 fg="magenta",
                 bold=True),
             default=True,
@@ -422,7 +422,7 @@ def edit_metadata(path, tags, metadata, source, rls_data, recompress, auto_renam
             
             if not result[0] and (config.YES_ALL or click.confirm(
                 click.style(
-                    "Do you want to sanitize this upload?",
+                    "\nDo you want to sanitize this upload?",
                     fg="magenta",
                     bold=True),
                 default=True,

--- a/salmon/uploader/__init__.py
+++ b/salmon/uploader/__init__.py
@@ -265,6 +265,7 @@ def upload(
             if len(searchstrs) > 0:
                 group_id = check_existing_group(gazelle_site, searchstrs)
 
+        spectral_ids = None
         if spectrals_after:
             lossy_master = False
             # We tell the uploader not to worry about it being lossy until later.
@@ -278,7 +279,7 @@ def upload(
             click.secho(f"New Source URL: {source_url}", fg="green")
         download_cover_if_nonexistent(path, metadata["cover"])
         path, metadata, tags, audio_info = edit_metadata(
-            path, tags, metadata, source, rls_data, recompress, auto_rename
+            path, tags, metadata, source, rls_data, recompress, auto_rename, spectral_ids
         )
         if not group_id:
             group_id = recheck_dupe(gazelle_site, searchstrs, metadata)
@@ -353,6 +354,7 @@ def upload(
             hybrid,
             lossy_master,
             spectral_urls,
+            spectral_ids,
             lossy_comment,
             request_id,
             source_url
@@ -362,7 +364,7 @@ def upload(
                 gazelle_site,
                 torrent_id,
                 spectral_urls,
-                track_data,
+                spectral_ids,
                 source,
                 lossy_comment,
                 source_url=source_url,
@@ -389,7 +391,7 @@ def upload(
             return click.secho("\nDone uploading this release.", fg="green")
 
 
-def edit_metadata(path, tags, metadata, source, rls_data, recompress, auto_rename):
+def edit_metadata(path, tags, metadata, source, rls_data, recompress, auto_rename, spectral_ids):
     """
     The metadata editing portion of the uploading process. This sticks the user
     into an infinite loop where the metadata process is repeated until the user
@@ -405,7 +407,7 @@ def edit_metadata(path, tags, metadata, source, rls_data, recompress, auto_renam
             recompress_path(path)
         path = rename_folder(path, metadata, auto_rename)
         if not metadata['scene']:
-            rename_files(path, tags, metadata, auto_rename, source)
+            rename_files(path, tags, metadata, auto_rename, spectral_ids, source)
             check_folder_structure(path)
 
         if config.YES_ALL or click.confirm(

--- a/salmon/uploader/upload.py
+++ b/salmon/uploader/upload.py
@@ -34,6 +34,7 @@ def prepare_and_upload(
     hybrid,
     lossy_master,
     spectral_urls,
+    spectral_ids,
     lossy_comment,
     request_id,
     source_url
@@ -49,6 +50,7 @@ def prepare_and_upload(
             hybrid,
             cover_url,
             spectral_urls,
+            spectral_ids,
             lossy_comment,
             request_id,
             source_url=source_url
@@ -61,6 +63,7 @@ def prepare_and_upload(
             track_data,
             hybrid,
             spectral_urls,
+            spectral_ids,
             lossy_comment,
             request_id,
             source_url=source_url
@@ -94,6 +97,7 @@ def compile_data_new_group(
     hybrid,
     cover_url,
     spectral_urls,
+    spectral_ids,
     lossy_comment,
     request_id=None,
     source_url=None
@@ -127,7 +131,7 @@ def compile_data_new_group(
         "image": cover_url,
         "album_desc": generate_description(track_data, metadata),
         "release_desc": generate_t_description(
-            metadata, track_data, hybrid, metadata["urls"], spectral_urls, lossy_comment, source_url
+            metadata, track_data, hybrid, metadata["urls"], spectral_urls, spectral_ids, lossy_comment, source_url
         ),
         'requestid': request_id,
     }
@@ -140,6 +144,7 @@ def compile_data_existing_group(
     track_data,
     hybrid,
     spectral_urls,
+    spectral_ids,
     lossy_comment,
     request_id,
     source_url=None
@@ -162,7 +167,7 @@ def compile_data_existing_group(
         "vbr": metadata["encoding_vbr"],
         "media": metadata["source"],
         "release_desc": generate_t_description(
-            metadata, track_data, hybrid, metadata["urls"], spectral_urls, lossy_comment, source_url
+            metadata, track_data, hybrid, metadata["urls"], spectral_urls, spectral_ids, lossy_comment, source_url
         ),
         'requestid': request_id,
     }
@@ -262,7 +267,7 @@ def generate_description(track_data, metadata):
 
 
 def generate_t_description(
-    metadata, track_data, hybrid, metadata_urls, spectral_urls, lossy_comment, source_url
+    metadata, track_data, hybrid, metadata_urls, spectral_urls, spectral_ids, lossy_comment, source_url
 ):
     """
     Generate the torrent description. Add information about each file, and
@@ -270,7 +275,7 @@ def generate_t_description(
     """
     description = ""
     if spectral_urls:
-        description += make_spectral_bbcode(list(track_data.keys()), spectral_urls)
+        description += make_spectral_bbcode(spectral_ids, spectral_urls)
 
     if not hybrid:
         track = next(iter(track_data.values()))


### PR DESCRIPTION
Fix mangled spectrals when file renaming was occuring

This was happening when initial files were named 1. xx, 2. xx, up to 10. xx
Lexical sorting was used, making the spectrals ids 1, 10, 2...

If file renaming was occuring, the spectrals uploaded on torrent description
were not matching the actual files.